### PR TITLE
chore: add oauth scopes to manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -15,6 +15,9 @@
       "type": "hidden"
     }
   },
+  "oauth": {
+    "scope": "openid+profile+offline_access"
+  },
   "data_types": [
     "profile",
     "contract",


### PR DESCRIPTION
This was missing, preventing us from configuring an account in collect.